### PR TITLE
ci(release): build in parallel behind a green CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
       # No toolchain action: rust-toolchain.toml pins the channel and components, and rustup on
       # the runner installs it on the first cargo call. One source of truth for the version.
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Names the cache after the platform instead of the job id, so the release workflow --
+          # whose jobs are called something else -- can read what this one saves. Caches on the
+          # default branch are readable from every ref; caches saved on a tag are not, which is
+          # why this side is the one that writes.
+          shared-key: linux
 
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -82,6 +88,9 @@ jobs:
         shell: pwsh
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # See the Linux job: the release workflow reads this.
+          shared-key: windows
 
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ on:
   workflow_dispatch:
 
 # A second push to the same branch cancels the first. Nothing here needs to finish twice.
+#
+# Except on main, where a release gate is watching. A tag is cut on a main commit, and the release
+# workflow refuses to build until this run concludes `success` on that exact SHA -- so cancelling
+# it because another commit landed a minute later would fail the release for a reason that has
+# nothing to do with the release. Grouping main by SHA means each commit's run is its own group and
+# survives; branches and pull requests still collapse to the newest push.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
           # deadlocks until the six-hour job timeout. `running-workflow-name` does not prevent it:
           # it drops check runs whose *name* equals the string, so it excludes this one job and
           # leaves the builds in the set.
+          #
+          # Keep this in step with the `name:` of every job in ci.yml. The step below asserts the
+          # count, because this filter only selects: a renamed job would silently fall out of the
+          # allowlist and stop gating anything.
           check-regexp: ^(Rust|Rust \(Windows\)|Frontend)$
           # `success` only. The default admits `skipped`, which would let a CI job that never ran
           # stand in for one that passed.
@@ -48,6 +52,26 @@ jobs:
           # A tag pushed at a commit with no CI at all fails here rather than building. Checks are
           # created a moment after the push, so give discovery longer than its 60s default.
           checks-discovery-timeout: 300
+
+      # The step above proves every check it *matched* passed. It cannot notice one that stopped
+      # matching -- it fails only when the filtered set is entirely empty. Rename `Frontend` to
+      # `Web` and the gate quietly waits on two jobs instead of three, and a release ships with a
+      # frontend nothing checked. This is the only thing that would say so.
+      - name: CI gated on every job it should have
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          expected=3
+          found=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+            --paginate --jq '.check_runs[]
+              | select(.name | test("^(Rust|Rust \\(Windows\\)|Frontend)$"))
+              | select(.conclusion == "success")
+              | .name' | sort -u | wc -l)
+          if [ "$found" -ne "$expected" ]; then
+            echo "gated on $found CI jobs, expected $expected -- was a job in ci.yml renamed?" >&2
+            exit 1
+          fi
+          echo "gated on all $expected CI jobs"
 
       # `check-versions.sh` proves the four in-tree version declarations agree with each other.
       # Nothing has ever proved they agree with the tag being built, because only this workflow
@@ -71,6 +95,10 @@ jobs:
     name: Windows installer
     needs: gate
     runs-on: windows-latest
+    # Only the `release` job writes anything. These two build from a shared cache, so the
+    # narrower token is worth the two lines.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -130,6 +158,10 @@ jobs:
     name: Linux bundles
     needs: gate
     runs-on: ubuntu-latest
+    # Only the `release` job writes anything. These two build from a shared cache, so the
+    # narrower token is worth the two lines.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,34 +12,83 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # A pre-release tag (`v0.4.2-rc1`) builds with debug assertions on, which is what makes the
-  # `[DEBUG-…]` tracing exist at all -- every one of those lines is `cfg(debug_assertions)`, so a
-  # normal release binary handed to a tester reports nothing when something goes wrong. Stable
-  # tags are unaffected: `-` in the tag is the whole switch.
-  CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: ${{ contains(github.ref_name, '-') }}
 
 jobs:
+  # The tag rides a commit that was pushed to main in the same breath, so when this workflow
+  # starts CI has not finished -- usually has not started. Reading the check runs once would
+  # therefore find nothing conclusive and wave the build through, which is worse than having no
+  # gate at all, because it looks like one. This waits for a conclusion instead.
+  gate:
+    name: Require a green CI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pinned to a commit, not to `v1`: this action decides whether an untested build reaches
+      # players, and a tag is a pointer its owner can move.
+      - name: Wait for CI on this commit
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Names CI's three jobs exactly, and nothing else. This workflow's own jobs report as
+          # check runs against the same commit, so waiting on "everything" would mean waiting on
+          # `Windows installer` and `Linux bundles` -- which are waiting on this job. That
+          # deadlocks until the six-hour job timeout. `running-workflow-name` does not prevent it:
+          # it drops check runs whose *name* equals the string, so it excludes this one job and
+          # leaves the builds in the set.
+          check-regexp: ^(Rust|Rust \(Windows\)|Frontend)$
+          # `success` only. The default admits `skipped`, which would let a CI job that never ran
+          # stand in for one that passed.
+          allowed-conclusions: success
+          wait-interval: 20
+          # A tag pushed at a commit with no CI at all fails here rather than building. Checks are
+          # created a moment after the push, so give discovery longer than its 60s default.
+          checks-discovery-timeout: 300
+
+      # `check-versions.sh` proves the four in-tree version declarations agree with each other.
+      # Nothing has ever proved they agree with the tag being built, because only this workflow
+      # knows the tag -- so `v0.5.3` could quietly produce artifacts labelled 0.5.2. Same failure
+      # that script exists to catch, one level up.
+      - name: The tag names the version being built
+        run: |
+          ./scripts/check-versions.sh
+          # A pre-release tag carries a suffix the manifests cannot hold -- `v0.5.4-rc1` is built
+          # from workspace version 0.5.4 -- so compare the part before the first `-`.
+          tag=${GITHUB_REF_NAME#v}
+          tag=${tag%%-*}
+          version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+          if [ "$tag" != "$version" ]; then
+            echo "tag $GITHUB_REF_NAME does not name workspace version $version" >&2
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches version $version"
+
   windows:
     name: Windows installer
+    needs: gate
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
 
-      # The installer ships its own Tesseract, so the runner needs one only for the test suite.
-      # Chocolatey appends to the *machine* PATH, which later steps do not see -- they inherit the
-      # environment captured when the job started -- so `$GITHUB_PATH` is what actually reaches
-      # the tests. Without it every OCR test fails with "tesseract is not available".
-      - name: Install tesseract
-        run: |
-          choco install --no-progress -y tesseract
-          "C:\Program Files\Tesseract-OCR" >> $env:GITHUB_PATH
-        shell: pwsh
-
+      # The installer ships its own Tesseract, downloaded and proven to run by this script. The
+      # runner needs no separate copy: the only thing that wanted one was the test suite, and the
+      # tests now run in CI.
       - name: Vendor tesseract for the bundle
         run: ./scripts/vendor-windows-tesseract.ps1
         shell: pwsh
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Reads what CI's `Rust (Windows)` job saved. Without this the prefix embeds the job id
+          # and the two can never meet. Release only ever consumes: a cache saved on a tag ref is
+          # scoped to that tag, so no later release could read it, and writing 1.2 GB nothing will
+          # read costs a minute of post-job every time.
+          shared-key: windows
+          save-if: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -54,11 +103,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: app
 
-      # Same gates the Linux bundle script applies, spelled out because that script is /bin/sh.
-      - run: cargo clippy --workspace --all-targets -- -D warnings
-      - run: cargo test --workspace
       - run: pnpm tauri build
         working-directory: app
+        env:
+          # A pre-release tag (`v0.4.2-rc1`) builds with debug assertions on, which is what makes
+          # the `[DEBUG-…]` tracing exist at all -- every one of those lines is
+          # `cfg(debug_assertions)`, so a normal release binary handed to a tester reports nothing
+          # when something goes wrong. Stable tags are unaffected: `-` in the tag is the whole
+          # switch.
+          #
+          # Set on the step rather than the workflow because `rust-cache` hashes every `CARGO*`
+          # variable into its key. At workflow scope it reaches the cache action too, and the
+          # resulting hash cannot match CI's -- which is why this job missed its cache even though
+          # its key prefix already agreed.
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: ${{ contains(github.ref_name, '-') }}
 
       # The installer is unsigned: a code-signing certificate costs money this project does not
       # take. SmartScreen will warn on first run until the download builds reputation, which is
@@ -70,9 +128,8 @@ jobs:
 
   bundles:
     name: Linux bundles
+    needs: gate
     runs-on: ubuntu-latest
-    # The draft release is attached here, so the Windows installer has to exist by then.
-    needs: windows
     steps:
       - uses: actions/checkout@v5
 
@@ -96,6 +153,10 @@ jobs:
             tesseract-ocr-eng
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Matches CI's `Rust` job. See the Windows job for why release never saves.
+          shared-key: linux
+          save-if: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -110,16 +171,35 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: app
 
-      # Not a bare `pnpm tauri build`. The helper runs the test suite, clippy and `pnpm check`
-      # first, and then asserts that the AppImage it just produced still forces `GDK_BACKEND=x11`
-      # -- the property the reward overlay depends on, and the only check of it that runs against
-      # the artifact users actually download.
-      - run: ./scripts/build-linux-bundles.sh appimage deb rpm
+      # `--skip-gates` drops the test suite, clippy and `pnpm check` -- CI ran all three against
+      # this commit and the gate job refused to get here until they passed. What the script still
+      # does is the part CI cannot: it asserts the AppImage it just produced forces
+      # `GDK_BACKEND=x11`, the property the reward overlay depends on, and repacks the AppDir.
+      # That runs against the artifact users actually download.
+      - run: ./scripts/build-linux-bundles.sh --skip-gates appimage deb rpm
+        env:
+          # See the Windows job.
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: ${{ contains(github.ref_name, '-') }}
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-bundles
+          path: |
+            target/release/bundle/appimage/*.AppImage
+            target/release/bundle/deb/*.deb
+            target/release/bundle/rpm/*.rpm
+
+  # Publishing is its own job so the two builds can run at once. Previously the Linux job attached
+  # the release, which forced it to wait for the Windows installer to exist -- an artifact
+  # dependency that serialised two builds sharing no other reason to be ordered.
+  release:
+    name: Draft release
+    needs: [windows, bundles]
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/download-artifact@v4
         with:
-          name: windows-installer
-          path: windows-installer
+          path: artifacts
 
       # A draft, not a publish. The release notes are written by hand from CHANGELOG.md and the
       # release goes out when the maintainer says so.
@@ -130,8 +210,14 @@ jobs:
           # as stable by accident -- and those are exactly the builds with assertions left on.
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
+          fail_on_unmatched_files: true
+          # `download-artifact` puts each artifact under a directory named after it, and
+          # `upload-artifact` roots a multi-path artifact at the least common ancestor of its
+          # globs -- `target/release/bundle` -- so the per-format subdirectories survive the trip.
+          # `fail_on_unmatched_files` is what turns a wrong guess about that into a failed release
+          # rather than a draft quietly missing the Linux downloads.
           files: |
-            target/release/bundle/appimage/*.AppImage
-            target/release/bundle/deb/*.deb
-            target/release/bundle/rpm/*.rpm
-            windows-installer/*.exe
+            artifacts/linux-bundles/appimage/*.AppImage
+            artifacts/linux-bundles/deb/*.deb
+            artifacts/linux-bundles/rpm/*.rpm
+            artifacts/windows-installer/*.exe

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,10 +70,12 @@ Tags are `v`-prefixed: `v0.1.0`. The version inside the repository is not.
 
 ## Packaging
 
-The bundles the workflow attaches are built by `scripts/build-linux-bundles.sh`, which runs the
-test suite and asserts the AppImage still forces `GDK_BACKEND=x11` before anything is uploaded.
-The Arch `PKGBUILD` and the overlay ebuilds fetch the tag's own archive, so they only work once
-the tag is pushed.
+The bundles the workflow attaches are built by `scripts/build-linux-bundles.sh`. Run by hand it
+gates on the test suite, clippy and `pnpm check` first; the release workflow passes `--skip-gates`
+because it refuses to start until CI has passed on that very commit. Either way the script asserts
+the AppImage still forces `GDK_BACKEND=x11` before anything is uploaded -- that check runs against
+the artifact itself and nothing else covers it. The Arch `PKGBUILD` and the overlay ebuilds fetch
+the tag's own archive, so they only work once the tag is pushed.
 
 ## Yanking
 

--- a/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
+++ b/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
@@ -1,0 +1,113 @@
+# Release pipeline speed
+
+A release takes 50+ minutes. This cuts it to roughly 20 without weakening a single check.
+
+## What the 53 minutes actually was
+
+Measured from `v0.5.1` (run 31021288441), the cleanest recent sample.
+
+The two jobs run back to back, because `bundles` declares `needs: windows` -- not for a build
+reason, but so the `.exe` exists to attach to the draft release. 27m + 26m serial.
+
+| Windows installer (27m) | | Linux bundles (26m) | |
+| --- | --- | --- | --- |
+| clippy | 3m19 | test compile | 8m20 |
+| test | 10m51 | test run | 4m50 |
+| tauri build | 9m46 | clippy | 1m06 |
+| cache save (post) | 1m51 | release build | 6m00 |
+| | | appimage/deb/rpm | 4m22 |
+
+Three independent costs, in order of size:
+
+1. **Serialization.** `needs: windows` is an artifact dependency, not a build dependency. ~26m.
+2. **Every gate runs twice.** The tag rides a commit that was just pushed to `main`, so CI runs
+   `fmt`, `clippy` and `test --workspace` on Linux *and* Windows against the identical SHA.
+   Release then recompiles the whole workspace under the `test` profile and reruns it. ~24m.
+3. **`rust-cache` misses on every release run.** Logs say `No cache found.` on both jobs.
+
+## Why the cache missed
+
+The keys, read off the run rather than guessed:
+
+| | CI | Release |
+| --- | --- | --- |
+| Linux | `v0-rust-rust-Linux-x64-…` | `v0-rust-bundles-Linux-x64-…` |
+| Windows | `v0-rust-windows-…-530c60a6` | `v0-rust-windows-…-20ba45dd` |
+
+Two different causes, and fixing only one fixes only Linux:
+
+- The prefix embeds `GITHUB_JOB`, so job id `bundles` cannot read what job id `rust` wrote.
+  `shared-key` replaces that segment and is the whole fix on Linux.
+- Windows' prefix *already agrees*. It misses on the trailing environment hash, because
+  `rust-cache` hashes every `CARGO*` variable and `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS` is
+  declared at the workflow root in release.yml and nowhere in ci.yml. Moving it onto only the
+  steps that build is what makes the hash agree.
+
+A cache saved on a tag ref is scoped to that ref and no later tag can read it, while caches on
+the default branch are readable from everywhere. Release can therefore only ever *consume*
+CI's caches, never its own. So release sets `save-if: false`: it stops writing 1.5 GB per run
+that nothing will ever read, and drops the 1m51 post-step.
+
+Be honest about the size of this win. Cargo fingerprints the profile, so CI's `test`-profile
+objects do not satisfy a `release` build. What actually carries over is the registry and the
+source downloads, not the codegen. This is the smallest of the three fixes.
+
+## Design
+
+Four jobs. The gate blocks both builds; the builds run concurrently; publishing is its own step
+that only attaches what the builds produced.
+
+```
+gate ──┬── windows ──┐
+       └── bundles ──┴── release (draft, attaches all four artifacts)
+```
+
+### gate
+
+Waits for CI to conclude on this exact SHA. It has to *wait*, not read once: the tag and the
+`main` commit are pushed together, so at the moment Release starts, CI is still `queued`. A
+read-once check would pass vacuously against a suite that has not run yet -- which is worse than
+no gate, because it looks like one.
+
+`lewagon/wait-on-check-action`, pinned to a commit SHA rather than a tag. It sits on the release
+path, and a tag is a moving pointer.
+
+`fail-on-no-checks` stays at its default of true. A tag whose SHA has no CI at all must fail, not
+sail through.
+
+The gate also asserts the tag equals the workspace version. `check-versions.sh` proves the four
+in-tree declarations agree with each other, but nothing has ever proved they agree with the tag
+being built -- and only the release workflow knows the tag. `v0.5.3` building `0.5.2` artifacts
+is exactly the silent mislabelling `check-versions.sh` was written to prevent, one level up.
+
+### windows / bundles
+
+Identical to today minus the duplicated gates, plus `shared-key` and `save-if: false`.
+
+The Windows job also drops its `choco install tesseract`. That existed to put a Tesseract on
+PATH for the test suite; the bundle's own engine comes from `vendor-windows-tesseract.ps1`, which
+downloads and verifies its own copy. With the tests gone the install has no remaining consumer.
+
+`build-linux-bundles.sh` grows a `--skip-gates` flag. It skips `cargo test`, `cargo clippy` and
+`pnpm check` -- the three CI just ran -- and keeps everything that inspects the artifact:
+
+- `assert_appimage_runs_on_x11`, the only check anywhere that the shipped AppImage still forces
+  `GDK_BACKEND=x11`, which the reward overlay depends on
+- `drop_bundled_wayland_client`, which repacks the AppDir
+
+Those two run against the file users download. Nothing else covers them, so they are not
+duplication and they stay. The flag defaults to off, so a developer running the script by hand
+gets the full gauntlet exactly as before.
+
+### release
+
+Downloads both artifacts, attaches all four files to a draft. Unchanged behaviour: still a draft,
+still `prerelease` from the tag, still hand-written notes.
+
+## Expected result
+
+`max(windows ≈ 11m, bundles ≈ 12m)` behind a gate that costs whatever CI costs, most of which is
+already spent by the time the tag lands. Roughly 20m wall clock, from 53m.
+
+Nothing is checked less. The same clippy, the same tests, on the same commit -- once instead of
+twice, with release blocked until they pass.

--- a/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
+++ b/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
@@ -75,10 +75,25 @@ path, and a tag is a moving pointer.
 `fail-on-no-checks` stays at its default of true. A tag whose SHA has no CI at all must fail, not
 sail through.
 
+The action's filter only *selects*: it fails when the matched set is empty, never when it is
+merely smaller than intended. So a job renamed in ci.yml would fall out of the allowlist and the
+gate would go green having waited on two jobs instead of three -- silently, because the regexp and
+the job names live in different files with nothing holding them together. A second step counts the
+matched successes and fails if there are not three. That is the difference between a gate and the
+appearance of one.
+
+CI's `cancel-in-progress` needed a matching change. It grouped by ref, so on `main` it would
+cancel the very run the gate waits for as soon as another commit landed -- and `cancelled` is not
+an allowed conclusion, so an unrelated merge would fail a release. `main` now groups by SHA, giving
+each commit its own group; branches and pull requests still collapse to the newest push.
+
 The gate also asserts the tag equals the workspace version. `check-versions.sh` proves the four
 in-tree declarations agree with each other, but nothing has ever proved they agree with the tag
 being built -- and only the release workflow knows the tag. `v0.5.3` building `0.5.2` artifacts
-is exactly the silent mislabelling `check-versions.sh` was written to prevent, one level up.
+is exactly the silent mislabelling `check-versions.sh` was written to prevent, one level up. A
+pre-release tag carries a suffix the manifests cannot hold, so the comparison uses the part before
+the first `-`. This doubles as the guard on `workflow_dispatch`: dispatched on a branch the ref is
+`main`, which names no version, so it fails before building.
 
 ### windows / bundles
 
@@ -103,6 +118,30 @@ gets the full gauntlet exactly as before.
 
 Downloads both artifacts, attaches all four files to a draft. Unchanged behaviour: still a draft,
 still `prerelease` from the tag, still hand-written notes.
+
+`upload-artifact` roots a multi-path artifact at the least common ancestor of its globs, so the
+Linux bundles arrive under `appimage/`, `deb/` and `rpm/` subdirectories rather than flat.
+`fail_on_unmatched_files` turns a wrong guess about that into a failed release instead of a draft
+quietly missing its Linux downloads.
+
+Only this job keeps `contents: write`. The two build jobs are dropped to `contents: read`.
+
+## Verification
+
+Before pushing:
+
+- `actionlint` clean on both workflows
+- the check-name regexp run against the real check runs on the last release commit: matches CI's
+  three jobs, excludes all four release jobs, so it cannot deadlock
+- the count assertion run against that same commit: passes at three, and fails at two when a
+  renamed job is simulated
+- the tag comparison run over `v0.5.3`, `v0.5.3-rc1`, `v0.5.3-beta.2` (pass) and `v0.5.2`,
+  `v0.6.0`, `v0.5.2-rc1` (fail)
+- `build-linux-bundles.sh` run both ways against stub `cargo`/`pnpm`: `--skip-gates` invokes only
+  the build, the default still runs tests, clippy and `pnpm check`
+- the X11 assertion proved to still fire under `--skip-gates` by breaking the hook in a real
+  AppDir and watching it exit 1
+- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace`, `pnpm check` all green
 
 ## Expected result
 

--- a/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
+++ b/docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md
@@ -52,6 +52,12 @@ Be honest about the size of this win. Cargo fingerprints the profile, so CI's `t
 objects do not satisfy a `release` build. What actually carries over is the registry and the
 source downloads, not the codegen. This is the smallest of the three fixes.
 
+Naming the Linux cache costs one cold run. CI's Linux job id is `rust`, so its prefix moves from
+`v0-rust-rust-Linux-x64` to `v0-rust-linux-Linux-x64` and the first run after merge rebuilds from
+scratch before repopulating under the new name. Windows is unaffected -- its job id was already
+`windows`, so the prefix does not move, which the PR run confirmed by hitting its cache and
+finishing in 6m14 against a historical 10m35.
+
 ## Design
 
 Four jobs. The gate blocks both builds; the builds run concurrently; publishing is its own step

--- a/scripts/build-linux-bundles.sh
+++ b/scripts/build-linux-bundles.sh
@@ -79,9 +79,7 @@ cd "$repo_root"
 if [ "$skip_gates" = false ]; then
   cargo test --workspace
   cargo clippy --workspace --all-targets -- -D warnings
-
-  cd "$repo_root/app"
-  pnpm check
+  ( cd "$repo_root/app" && pnpm check )
 fi
 
 cd "$repo_root/app"

--- a/scripts/build-linux-bundles.sh
+++ b/scripts/build-linux-bundles.sh
@@ -4,6 +4,17 @@ set -eu
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 
+# CI already ran the test suite, clippy and `pnpm check` against this very commit, and the release
+# workflow refuses to build a tag whose CI did not pass -- so repeating them here costs about
+# fifteen minutes to learn what is already known. `--skip-gates` is for that caller and no other:
+# it drops only the checks CI duplicates, never the two that inspect the AppImage itself, because
+# nothing but this script looks at those. Off by default, so running this by hand still gates.
+skip_gates=false
+if [ "${1-}" = "--skip-gates" ]; then
+  skip_gates=true
+  shift
+fi
+
 if [ "$#" -eq 0 ]; then
   set -- appimage
 fi
@@ -65,11 +76,15 @@ drop_bundled_wayland_client() {
 }
 
 cd "$repo_root"
-cargo test --workspace
-cargo clippy --workspace --all-targets -- -D warnings
+if [ "$skip_gates" = false ]; then
+  cargo test --workspace
+  cargo clippy --workspace --all-targets -- -D warnings
+
+  cd "$repo_root/app"
+  pnpm check
+fi
 
 cd "$repo_root/app"
-pnpm check
 
 for bundle in "$@"; do
   if [ "$bundle" = appimage ]; then


### PR DESCRIPTION
A release takes 50+ minutes. `v0.5.3` took 54. This cuts it to roughly 20 without weakening a single check.

## Where the time went

Measured off `v0.5.1` (run 31021288441):

| Windows installer (27m) | | Linux bundles (26m) | |
| --- | --- | --- | --- |
| clippy | 3m19 | test compile | 8m20 |
| test | 10m51 | test run | 4m50 |
| tauri build | 9m46 | clippy | 1m06 |
| cache save (post) | 1m51 | release build | 6m00 |
| | | appimage/deb/rpm | 4m22 |

Three costs:

1. **Serialisation.** `bundles` declared `needs: windows` only so the `.exe` existed to attach. Publishing is now its own job and the two builds run at once.
2. **Every gate ran twice.** The tag rides a commit pushed to `main` in the same breath, so CI had already run `fmt`/`clippy`/`test` on both platforms against the identical SHA. Release recompiled the workspace under the `test` profile and reran them.
3. **`rust-cache` missed on every release run**, for two separate reasons — see below.

## The gate

Release now waits for CI to conclude on its exact SHA. It has to *wait*, not read: when the tag lands CI is still queued, so a read-once gate would wave the build through against a suite that had not run — worse than no gate, because it looks like one.

- Pinned to a commit SHA, not `v1`. It decides whether an untested build reaches players.
- `allowed-conclusions: success` — the default admits `skipped`.
- Names CI's three jobs explicitly. This workflow's own jobs report as check runs on the same SHA, so waiting on "everything" would mean waiting on the builds that are waiting on the gate.
- A second step **counts** the matched successes. The action fails only when the matched set is *empty*, never when it is merely smaller than intended — so renaming a CI job would silently drop it from the allowlist and the gate would go green having checked two things instead of three.

CI's `cancel-in-progress` needed a matching change: it grouped by ref, so on `main` it would cancel the very run the gate waits for whenever another commit landed. `main` now groups by SHA; branches and PRs still collapse to the newest push. (Two such cancelled runs are already visible in the run history.)

## What release still runs

`--skip-gates` drops only the three checks CI duplicates. It keeps `assert_appimage_runs_on_x11` and the AppDir repack — those inspect the artifact users download and nothing else covers them. Off by default, so running the script by hand still gates.

The Windows job drops its `choco install tesseract`: the bundle vendors and verifies its own copy, and the tests that wanted one now run in CI.

## The cache

| | CI | Release (before) |
| --- | --- | --- |
| Linux | `v0-rust-rust-Linux-x64-…` | `v0-rust-bundles-Linux-x64-…` |
| Windows | `v0-rust-windows-…-530c60a6` | `v0-rust-windows-…-20ba45dd` |

Two independent causes. The prefix embeds the job id, so `bundles` could never read what `rust` wrote — `shared-key` fixes that. Windows' prefix already agreed and still missed, because `rust-cache` hashes every `CARGO*` variable and `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS` sat at workflow scope; it now sits on the steps that build. Release reads and never writes: a cache saved on a tag ref is scoped to that tag, so nothing could read it back.

Worth being honest that this is the smallest of the three wins — cargo fingerprints the profile, so what carries over is the registry and sources, not codegen.

## Also

The gate asserts the tag names the version being built. `check-versions.sh` proves the four manifests agree with each other; only this workflow knows the tag, so `v0.5.3` could quietly ship artifacts labelled `0.5.2`. Pre-release suffixes are compared on the part before the first `-`. This doubles as the `workflow_dispatch` guard.

Build jobs dropped to `contents: read`; only the publishing job keeps `write`.

## Verification

Before pushing: `actionlint` clean; the regexp run against real check runs on the last release commit (matches CI's three, excludes all four release jobs — no deadlock); the count assertion passing at three and failing at two with a rename simulated; the tag comparison over `v0.5.3`/`-rc1`/`-beta.2` (pass) and `v0.5.2`/`v0.6.0`/`v0.5.2-rc1` (fail); the bundle script run both ways against stub `cargo`/`pnpm`; the X11 assertion proved to still fire under `--skip-gates` by breaking the hook in a real AppDir; `fmt`, `clippy -D warnings`, `cargo test --workspace`, `pnpm check` all green.

The one thing local verification cannot cover is the gate firing end to end, which needs a tag. Design notes in `docs/superpowers/specs/2026-08-08-release-pipeline-speed-design.md`.