### PR TITLE
fix: prefer newest Linux game process after relaunch

### DIFF
--- a/crates/warframe-acquisition/src/linux_proc.rs
+++ b/crates/warframe-acquisition/src/linux_proc.rs
@@ -152,7 +152,9 @@ impl ProcessDiscovery for LinuxProc {
             }
         }
 
-        candidates.sort_unstable_by_key(|&(priority, pid, _)| (Reverse(priority), pid));
+        candidates.sort_unstable_by_key(|&(priority, pid, start_time)| {
+            (Reverse(priority), Reverse(start_time), pid)
+        });
         let selected = candidates
             .first()
             .map(|&(_, pid, start_time)| GameProcess::identified(pid, start_time));

--- a/crates/warframe-acquisition/tests/linux_proc.rs
+++ b/crates/warframe-acquisition/tests/linux_proc.rs
@@ -94,6 +94,40 @@ fn a_relaunch_is_discovered_from_the_new_process_rather_than_the_dying_one() {
 }
 
 #[test]
+fn executable_name_priority_outranks_a_newer_lower_priority_process() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = "/games/Warframe/Downloaded/Public/Warframe.x64.exe";
+    candidate_started_at(temp.path(), 100, "Warframe.x64.exe", executable, 777);
+    candidate_started_at(temp.path(), 200, "Warframe.x64.ex", executable, 778);
+
+    assert_eq!(
+        LinuxProc::at(temp.path())
+            .discover()
+            .unwrap()
+            .map(GameProcess::pid),
+        Some(100),
+        "the full executable name has higher priority"
+    );
+}
+
+#[test]
+fn equal_name_priority_and_start_time_use_the_lower_pid() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = "/games/Warframe/Downloaded/Public/Warframe.x64.exe";
+    candidate_started_at(temp.path(), 300, "Warframe.x64.exe", executable, 777);
+    candidate_started_at(temp.path(), 200, "Warframe.x64.exe", executable, 777);
+
+    assert_eq!(
+        LinuxProc::at(temp.path())
+            .discover()
+            .unwrap()
+            .map(GameProcess::pid),
+        Some(200),
+        "the lower PID is the deterministic tie-break"
+    );
+}
+
+#[test]
 fn discovery_ignores_vanished_and_malformed_process_entries() {
     let temp = tempfile::tempdir().unwrap();
     write_file(temp.path(), "not-a-pid/comm", "Warframe.x64.exe\n");

--- a/crates/warframe-acquisition/tests/linux_proc.rs
+++ b/crates/warframe-acquisition/tests/linux_proc.rs
@@ -14,8 +14,18 @@ fn write_file(root: &Path, relative: &str, contents: impl AsRef<[u8]>) {
 }
 
 fn candidate(root: &Path, pid: u32, comm: &str, mapped_executable: &str) {
+    candidate_started_at(root, pid, comm, mapped_executable, 777);
+}
+
+fn candidate_started_at(
+    root: &Path,
+    pid: u32,
+    comm: &str,
+    mapped_executable: &str,
+    start_time: u64,
+) {
     write_file(root, &format!("{pid}/comm"), format!("{comm}\n"));
-    write_stat(root, pid, comm, 777);
+    write_stat(root, pid, comm, start_time);
     write_file(
         root,
         &format!("{pid}/maps"),
@@ -64,6 +74,23 @@ fn discovers_full_and_wine_truncated_names_only_when_the_game_executable_is_mapp
     let process = LinuxProc::at(temp.path()).discover().unwrap().unwrap();
 
     assert_eq!(process.pid(), 102);
+}
+
+#[test]
+fn a_relaunch_is_discovered_from_the_new_process_rather_than_the_dying_one() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = "/games/Warframe/Downloaded/Public/Warframe.x64.exe";
+    candidate_started_at(temp.path(), 100, "Warframe.x64.exe", executable, 777);
+    candidate_started_at(temp.path(), 200, "Warframe.x64.exe", executable, 778);
+
+    assert_eq!(
+        LinuxProc::at(temp.path())
+            .discover()
+            .unwrap()
+            .map(GameProcess::pid),
+        Some(200),
+        "the replacement process has the newest start time"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- prefer the newest matching Warframe process when Linux discovery sees a relaunch
- preserve full executable-name priority over Wine's truncated process name
- retain the lower PID as a deterministic final tie-break
- cover relaunch, name-priority, and equal-start-time ordering with regression tests

## Root cause

Linux process discovery already captured each candidate's start time, but equal-name
candidates were ordered by PID. During a quick game relaunch, that could select the
older, dying process instead of the replacement process.

The ordering is now executable-name priority, newest start time, then lower PID.

## Impact

After Warframe relaunches, acquisition can attach to the replacement process
immediately instead of briefly selecting the stale process.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p warframe-acquisition` — 220 passed, 3 ignored
- `cd app && pnpm check` — lint and type-check passed; 112 tests passed

The full workspace test command also reaches an existing local OCR fixture mismatch
under Tesseract 5.5.3: the 16:10 reward-screen case scores `0.875` against a `0.9`
threshold. The same failure was reproduced on the upstream base before this change.
